### PR TITLE
Add docs to existing public items

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -4,10 +4,10 @@
 
 ## Rust for the Windows App SDK
 
-The `windows-app` crate makes the [Windows App SDK](https://github.com/microsoft/WindowsAppSDK) available to Rust developers. It is powered by the the [windows](https://github.com/microsoft/windows-rs) crate.
+The `windows-app` crate makes the [Windows App SDK](https://github.com/microsoft/WindowsAppSDK) (formerly known as Project Reunion) available to Rust developers. It is powered by the the [windows](https://github.com/microsoft/windows-rs) crate.
 
-It's early days, but the `windows-app` crate is meant to make it much easier to use the Windows App SDK from Rust. As this new set of APIs requires bootstrapping and various other hooks to get it up and running, using only the `windows` crate—while possible—is a little more cumbersome for these new APIs. 
+It's early days, but the `windows-app` crate is meant to make it much easier to use the Windows App SDK from Rust. As this new set of APIs requires bootstrapping and various other hooks to get it up and running, using only the `windows` crate—while possible—is a little more cumbersome for these new APIs.
 
-So while the `windows` crate is still essential as it provides all of the language support, the `windows-app` crate will provide the necessary bootstrapping unique to the Windows App SDK. 
+So while the `windows` crate is still essential as it provides all of the language support, the `windows-app` crate will provide the necessary bootstrapping unique to the Windows App SDK.
 
 As WinUI is a large part of the Windows App SDK, the goal is to support the latest WinUI app development through the `windows-app` crate.

--- a/bindings/build.rs
+++ b/bindings/build.rs
@@ -1,5 +1,6 @@
 fn main() {
     windows::build! {
-        Windows::Win32::UI::WindowsAndMessaging::MessageBoxW
+        Windows::Win32::UI::WindowsAndMessaging::MessageBoxW,
+        Windows::Win32::Foundation::HWND,
     };
 }

--- a/bindings/build.rs
+++ b/bindings/build.rs
@@ -1,6 +1,5 @@
 fn main() {
     windows::build! {
         Windows::Win32::UI::WindowsAndMessaging::MessageBoxW,
-        Windows::Win32::Foundation::HWND,
     };
 }

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -1,24 +1,33 @@
+/*!
+Utilities for bootstrapping an app that uses the Windows App SDK.
+!*/
 use bindings::Windows::Win32::{
     Foundation::HWND,
     UI::WindowsAndMessaging::{MessageBoxW, MB_ICONERROR, MB_OK},
 };
 
+/// A target version of the Windows App SDK.
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct PackageVersion {
+    /// The build revision
     pub revision: u8,
+    /// The build version
     pub build: u8,
+    /// The minor version
     pub minor: u8,
+    /// The major version
     pub major: u8,
 }
 
 impl PackageVersion {
+    /// Create a new Windows App SDK package version.
     pub fn new(major: u8, minor: u8, build: u8, revision: u8) -> Self {
         Self {
-            revision,
-            build,
-            minor,
             major,
+            minor,
+            build,
+            revision,
         }
     }
 
@@ -87,8 +96,12 @@ extern "system" {
 }
 
 /// Locates the Windows App framework package compatible with the (currently internal)
-/// versioning criteria and loads it into the current process. If multiple packages meet
-/// the criteria, the best candidate is selected.
+/// versioning criteria and loads it into the current process.
+///
+/// On error a dialogue box will be displayed. To not have the dialogue box displayed,
+/// use [`initialize_without_dialog`] instead.
+///
+/// If multiple packages meet the criteria, the best candidate is selected.
 pub fn initialize() -> windows::Result<()> {
     initialize_without_dialog()
     .map_err(|outer_error| {
@@ -104,6 +117,8 @@ pub fn initialize() -> windows::Result<()> {
     })
 }
 
+/// Locates the Windows App framework package compatible with the (currently internal)
+/// versioning criteria and loads it into the current process.
 pub fn initialize_without_dialog() -> windows::Result<()> {
     let version_tag: Vec<u16> = "preview".encode_utf16().collect();
     let mdd_version = PackageVersion {
@@ -128,7 +143,7 @@ pub fn initialize_without_dialog() -> windows::Result<()> {
     }
 }
 
-/// Undo the changes made by `initialize()`
+/// Undo the changes made by `initialize()`.
 pub fn uninitialize() -> windows::Result<()> {
     unsafe { MddBootstrapShutdown().ok() }
 }

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -6,10 +6,10 @@ use bindings::Windows::Win32::{
     UI::WindowsAndMessaging::{MessageBoxW, MB_ICONERROR, MB_OK},
 };
 
-/// A target version of the Windows App SDK.
+/// The minimum framework package compatible with the app.
 #[repr(C)]
 #[derive(Clone, Copy)]
-pub struct PackageVersion {
+struct PackageVersion {
     /// The build revision
     pub revision: u8,
     /// The build version
@@ -21,16 +21,6 @@ pub struct PackageVersion {
 }
 
 impl PackageVersion {
-    /// Create a new Windows App SDK package version.
-    pub fn new(major: u8, minor: u8, build: u8, revision: u8) -> Self {
-        Self {
-            major,
-            minor,
-            build,
-            revision,
-        }
-    }
-
     fn to_major_minor(self) -> u32 {
         ((self.major as u32) << 8) | self.minor as u32
     }
@@ -95,10 +85,10 @@ extern "system" {
     fn MddBootstrapShutdown() -> windows::HRESULT;
 }
 
-/// Locates the Windows App framework package compatible with the (currently internal)
+/// Locates the Windows App SDK framework package compatible with the (currently internal)
 /// versioning criteria and loads it into the current process.
 ///
-/// On error a dialogue box will be displayed. To not have the dialogue box displayed,
+/// On error a dialog box will be displayed. To not have the dialog box displayed,
 /// use [`initialize_without_dialog`] instead.
 ///
 /// If multiple packages meet the criteria, the best candidate is selected.
@@ -108,7 +98,7 @@ pub fn initialize() -> windows::Result<()> {
         unsafe {
             MessageBoxW(
                 HWND::default(),
-                "To run this application, the Windows App preview runtime must be installed.\n\nhttps://aka.ms/projectreunion/0.8preview",
+                "To run this application, the Windows App SDK preview runtime must be installed.\n\nhttps://aka.ms/projectreunion/0.8preview",
                 "This application could not be started",
                 MB_OK | MB_ICONERROR,
             );
@@ -117,7 +107,7 @@ pub fn initialize() -> windows::Result<()> {
     })
 }
 
-/// Locates the Windows App framework package compatible with the (currently internal)
+/// Locates the Windows App SDK framework package compatible with the (currently internal)
 /// versioning criteria and loads it into the current process.
 pub fn initialize_without_dialog() -> windows::Result<()> {
     let version_tag: Vec<u16> = "preview".encode_utf16().collect();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,27 @@
+/*!
+The `windows-app` crate makes the [Windows App SDK](https://github.com/microsoft/WindowsAppSDK) available to Rust developers making it possible
+to create modern Windows app in pure Rust.
+
+It is powered by the the [windows](https://github.com/microsoft/windows-rs) crate.
+
+Bootstrapping a Windows app with `windows-app` is easy:
+
+```rust,no_run
+#![windows_subsystem = "console"]
+
+fn main() -> windows::Result<()> {
+    windows_app::bootstrap::initialize()
+}
+```
+
+
+For examples of how to create a window and fill that window with UI elements, take a look at the examples [here][examples].
+
+[examples]: https://github.com/microsoft/windows-samples-rs/tree/be806aad53ebc563d8957908f94881338658a8a0/windows_app_sdk
+!*/
+
+#![deny(missing_docs)]
+
 pub mod bootstrap;
 
 use windows::{IInspectable, Interface, HRESULT};
@@ -50,6 +74,13 @@ unsafe impl ::windows::Interface for IWindowNative {
     );
 }
 
+/// Get a window handle (`HWND`) from a window object.
+///
+/// Returns `None` if the supplied window cannot be cast to an [`IWindowNative`][IWindowNative]
+/// or if [`IWindowNative::get_WindowHandle`][WindowHandle] errors
+///
+/// [IWindowNative]: https://docs.microsoft.com/windows/windows-app-sdk/api/win32/microsoft.ui.xaml.window/nn-microsoft-ui-xaml-window-iwindownative
+/// [WindowHandle]: https://docs.microsoft.com/windows/windows-app-sdk/api/win32/microsoft.ui.xaml.window/nf-microsoft-ui-xaml-window-iwindownative-get_windowhandle
 pub fn window_handle(window: &IInspectable) -> Option<isize> {
     window.cast::<IWindowNative>().unwrap().handle()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,10 @@
 /*!
 The `windows-app` crate makes the [Windows App SDK](https://github.com/microsoft/WindowsAppSDK) available to Rust developers making it possible
-to create modern Windows app in pure Rust.
+to create Windows apps in pure Rust.
 
 It is powered by the the [windows](https://github.com/microsoft/windows-rs) crate.
 
-Bootstrapping a Windows app with `windows-app` is easy:
+Bootstrapping a Windows app with `windows-app` is simple:
 
 ```rust,no_run
 #![windows_subsystem = "console"]


### PR DESCRIPTION
This adds docs to all existing public items.

Additionally it adds a `#![deny(missing_docs)]` attribute to encourage adding docs to anything that is public. If it's too early to document an `#[allow(missing_docs)]` can be added to that item. I've found it easier to just make sure to document as we go rather than having to fill it in later on. 

![Web capture_26-6-2021_163659_](https://user-images.githubusercontent.com/1327285/123518006-5f7de980-d6a4-11eb-9893-32a4fe298e1f.jpeg)
